### PR TITLE
N°787 - Allow to anonymize synchronized person

### DIFF
--- a/datamodel.combodo-anonymizer.xml
+++ b/datamodel.combodo-anonymizer.xml
@@ -11,6 +11,7 @@
       <max_interactive_anonymization_time_in_s>30</max_interactive_anonymization_time_in_s>
       <anonymize_obsolete_persons>false</anonymize_obsolete_persons>
       <obsolete_persons_retention>-1</obsolete_persons_retention>
+      <synchronisation_policy>delete</synchronisation_policy>
       <caselog_content type="array">
         <field id="0">friendlyname</field>
         <field id="1">email</field>

--- a/module.combodo-anonymizer.php
+++ b/module.combodo-anonymizer.php
@@ -48,6 +48,7 @@ SetupWebPage::AddModule(
 			'src/Hook/AnonymizationMenuPlugIn.php',
 			'src/Hook/AnonymizationJsPlugin.php',
 			'model.combodo-anonymizer.php',
+			'src/Action/ActionManageSynchronization.php',
 			'src/Action/ActionAnonymizePerson.php',
 			'src/Action/ActionCleanupCaseLogs.php',
 			'src/Action/ActionCleanupEmailNotification.php',

--- a/src/Action/ActionManageSynchronization.php
+++ b/src/Action/ActionManageSynchronization.php
@@ -71,6 +71,7 @@ class ActionManageSynchronization extends AnonymizationTaskAction
 						if ($sSynchroPolicy=='delete') {
 							$oObj->DBDelete();
 						} else {
+							$oObj->Set('status','obsolete');
 							$oObj->Set('dest_id',0);
 							$oObj->DBWrite();
 						}

--- a/src/Action/ActionManageSynchronization.php
+++ b/src/Action/ActionManageSynchronization.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * @copyright   Copyright (C) 2010-2022 Combodo SARL
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
+
+use Combodo\iTop\Anonymizer\Helper\AnonymizerHelper;
+use Combodo\iTop\Anonymizer\Helper\AnonymizerLog;
+use Combodo\iTop\Anonymizer\Service\CleanupService;
+
+/**
+ * Set new values in Person to anonymize its data
+ */
+class ActionManageSynchronization extends AnonymizationTaskAction
+{
+	/**
+	 * @throws \CoreException
+	 */
+	public static function Init()
+	{
+		$aParams = array
+		(
+			'category'            => '',
+			'key_type'            => 'autoincrement',
+			'name_attcode'        => 'name',
+			'state_attcode'       => '',
+			'reconc_keys'         => array('name'),
+			'db_table'            => 'priv_anonym_action_manage_synchro',
+			'db_key_field'        => 'id',
+			'db_finalclass_field' => '',
+			'display_template'    => '',
+		);
+		MetaModel::Init_Params($aParams);
+		MetaModel::Init_InheritAttributes();
+
+		// Display lists
+		MetaModel::Init_SetZListItems('list', array('name', 'rank')); // Attributes to be displayed for a list
+		// Search criteria
+		MetaModel::Init_SetZListItems('standard_search', array('name')); // Criteria of the std search form
+	}
+
+	public function ChangeActionParamsOnError(): bool
+	{
+		// Cannot continue with the action
+		$oTask = $this->GetTask();
+
+		$sClass = Person::class;
+		$sId = $oTask->Get('person_id');
+
+		AnonymizerLog::Error("Anonymization ActionManageSynchronization of $sClass::$sId Failed");
+		return false;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function ExecuteAction($iEndExecutionTime): bool
+	{
+		$sSynchroPolicy = MetaModel::GetModuleSetting(AnonymizerHelper::MODULE_NAME,'synchronisation_policy', '');
+		switch($sSynchroPolicy) {
+			case 'delete':
+			case 'forget':
+				$oTask = $this->GetTask();
+				$sClass = Person::class;
+				$sId = $oTask->Get('person_id');
+				$sOql = 'SELECT SynchroReplica WHERE dest_class=\''.$sClass.'\' AND dest_id='.$sId;
+				$oSearch = DBObjectSearch::FromOQL($sOql);
+				$oSet = new DBObjectSet($oSearch);
+				try {
+					while ($oObj = $oSet->Fetch()) {
+						if ($sSynchroPolicy=='delete') {
+							$oObj->DBDelete();
+						} else {
+							$oObj->Set('dest_id',0);
+							$oObj->DBWrite();
+						}
+					}
+				}
+				catch (Exception $e) {
+					AnonymizerLog::Error('ActionManageSynchronization: '.$e->getMessage());
+				}
+			break;
+
+			default:
+				//do nothing
+		}
+		$aContext = json_decode($oTask->Get('anonymization_context'), true);
+		AnonymizerLog::Debug('Anonymization context: '.var_export($aContext, true));
+
+		$oTask->Set('anonymization_context', json_encode($aContext));
+		try {
+			$oTask->DBWrite();
+		} catch (Exception $e) {
+			AnonymizerLog::Error('ActionManageSynchronization: '.$e->getMessage());
+		}
+		return true;
+	}
+}

--- a/src/Helper/AnonymizerHelper.php
+++ b/src/Helper/AnonymizerHelper.php
@@ -19,6 +19,7 @@ class AnonymizerHelper
 	const ADAPTATIVE_MAX_TIME = 60.0;
 	const ADAPTATIVE_MAX_CHUNK_SIZE = 100000000;
 	const ACTION_LIST = [
+		'ActionManageSynchronization',
 		'ActionResetPersonFields',
         'ActionAnonymizePerson',
         'ActionCleanupCaseLogs',


### PR DESCRIPTION
Add a new param "synchronisation_policy" with 3 values : "delete", "forget", "none"
- delete : search if the a replica exists and delete this replica and then anonymize ->if the synchronization push again the person, it will be recreate
- forget : search if the a replica exists and change dest_id to 0, status to obsolete in this replica and then anonymize->if the synchronization push again the person, it will be ignored
- none : do nothing and try to anonymize => it will fail if a replica exist

It remains to decide what is the default setting